### PR TITLE
Update bitstable.clar

### DIFF
--- a/contracts/bitstable.clar
+++ b/contracts/bitstable.clar
@@ -1,23 +1,12 @@
 ;; BitStable Protocol - Bitcoin-Collateralized Stablecoin System
 ;;
-;; A next-generation decentralized stablecoin protocol leveraging Bitcoin's security
-;; and Stacks' smart contract capabilities to create a truly decentralized USD-pegged
-;; digital asset. BitStable enables users to mint stablecoins by locking STX as 
-;; collateral, with autonomous liquidation mechanisms and oracle-driven price feeds.
-;;
-;; Core Features:
-;; - Over-collateralized vault system with configurable ratios
-;; - Automated liquidation engine protecting protocol solvency
-;; - Multi-oracle price feed integration for robust price discovery
-;; - Governance-controlled risk parameters and emergency controls
-;; - Fee-based sustainability model with transparent economics
-;;
-;; Security Model:
-;; BitStable implements a battle-tested CDP (Collateralized Debt Position) model
-;; with multiple layers of protection including minimum collateral ratios,
-;; liquidation thresholds, and emergency shutdown capabilities.
+;; Next-generation decentralized stablecoin leveraging BTC security and Stacks smart contracts.
+;; Includes vaults, over-collateralization, automated liquidation, oracle feeds, governance, 
+;; and time-weighted stability fee accrual.
 
-;; PROTOCOL CONSTANTS
+;; ========================================
+;; CONSTANTS & ERROR CODES
+;; ========================================
 
 (define-constant CONTRACT_OWNER tx-sender)
 (define-constant ERR_OWNER_ONLY (err u100))
@@ -30,82 +19,87 @@
 (define-constant ERR_EMERGENCY_SHUTDOWN (err u107))
 (define-constant ERR_INVALID_PARAMETER (err u108))
 
-;; Price and ratio boundaries for system safety
-(define-constant MAXIMUM_PRICE u1000000000) ;; $10,000 BTC price ceiling
-(define-constant MINIMUM_PRICE u1) ;; $0.01 BTC price floor
-(define-constant MAXIMUM_RATIO u1000) ;; 1000% max collateral ratio
-(define-constant MINIMUM_RATIO u101) ;; 101% min collateral ratio
-(define-constant MAXIMUM_FEE u100) ;; 100% max stability fee cap
+;; Price & ratio boundaries
+(define-constant MAXIMUM_PRICE u1000000000)
+(define-constant MINIMUM_PRICE u1)
+(define-constant MAXIMUM_RATIO u1000)
+(define-constant MINIMUM_RATIO u101)
+(define-constant MAXIMUM_FEE u100)
 
-;; PROTOCOL STATE VARIABLES
+;; ========================================
+;; STATE VARIABLES
+;; ========================================
 
-;; Risk management parameters
-(define-data-var minimum-collateral-ratio uint u150) ;; 150% - Safe collateralization
-(define-data-var liquidation-ratio uint u120) ;; 120% - Liquidation trigger
-(define-data-var stability-fee uint u2) ;; 2% - Annual borrowing cost
+(define-data-var minimum-collateral-ratio uint u150)
+(define-data-var liquidation-ratio uint u120)
+(define-data-var stability-fee uint u2)
 
-;; System state controls
 (define-data-var initialized bool false)
 (define-data-var emergency-shutdown bool false)
 
-;; Oracle price feed data
 (define-data-var last-price uint u0)
 (define-data-var price-valid bool false)
 
-;; Governance token reference
 (define-data-var governance-token principal 'SP000000000000000000002Q6VF78.governance-token)
 
-;; DATA STRUCTURES
-
-;; User vault storage - tracks collateral and debt positions
+;; Vault storage
 (define-map vaults
   principal
   {
-    collateral: uint, ;; STX collateral locked
-    debt: uint, ;; BitStable tokens minted
-    last-fee-timestamp: uint, ;; Last stability fee calculation
+    collateral: uint
+    debt: uint
+    last-fee-timestamp: uint
   }
 )
 
-;; Authorized liquidator registry
+;; Authorized liquidators
 (define-map liquidators
   principal
   bool
 )
 
-;; Authorized price oracle registry  
+;; Authorized price oracles
 (define-map price-oracles
   principal
   bool
 )
 
+;; ========================================
 ;; VALIDATION FUNCTIONS
+;; ========================================
 
 (define-private (is-valid-price (price uint))
-  ;; Validates price falls within acceptable bounds
-  (and
-    (>= price MINIMUM_PRICE)
-    (<= price MAXIMUM_PRICE)
-  )
+  (and (>= price MINIMUM_PRICE) (<= price MAXIMUM_PRICE))
 )
 
 (define-private (is-valid-ratio (ratio uint))
-  ;; Validates collateral ratio is within system limits
-  (and
-    (>= ratio MINIMUM_RATIO)
-    (<= ratio MAXIMUM_RATIO)
-  )
+  (and (>= ratio MINIMUM_RATIO) (<= ratio MAXIMUM_RATIO))
 )
 
 (define-private (is-valid-fee (fee uint))
-  ;; Validates stability fee doesn\'t exceed maximum
   (<= fee MAXIMUM_FEE)
 )
 
+;; ========================================
+;; HELPER: TIME-WEIGHTED STABILITY FEE ACCRUAL
+;; ========================================
+
+(define-private (accrue-stability-fee (vault-data {collateral: uint, debt: uint, last-fee-timestamp: uint}))
+  (let (
+        (blocks-passed (- stacks-block-height (get last-fee-timestamp vault-data)))
+        (fee-rate (var-get stability-fee))
+        (fee-accrued (/ (* (get debt vault-data) fee-rate blocks-passed) u10000))
+        (new-debt (+ (get debt vault-data) fee-accrued))
+  )
+    (merge vault-data { debt: new-debt, last-fee-timestamp: stacks-block-height })
+  )
+)
+
+;; ========================================
 ;; CORE PROTOCOL FUNCTIONS
+;; ========================================
 
 (define-public (initialize (btc-price uint))
-  ;; Initializes the BitStable protocol with starting BTC price
   (begin
     (asserts! (is-eq tx-sender CONTRACT_OWNER) ERR_OWNER_ONLY)
     (asserts! (not (var-get initialized)) ERR_ALREADY_INITIALIZED)
@@ -117,15 +111,13 @@
   )
 )
 
+;; Create or add collateral
 (define-public (create-vault (collateral-amount uint))
-  ;; Creates or adds collateral to a user\'s vault position
   (let ((existing-vault (default-to {
-      collateral: u0,
-      debt: u0,
-      last-fee-timestamp: stacks-block-height,
-    }
-      (map-get? vaults tx-sender)
-    )))
+      collateral: u0
+      debt: u0
+      last-fee-timestamp: stacks-block-height
+    } (map-get? vaults tx-sender))))
     (begin
       (asserts! (var-get initialized) ERR_NOT_INITIALIZED)
       (asserts! (not (var-get emergency-shutdown)) ERR_EMERGENCY_SHUTDOWN)
@@ -138,104 +130,89 @@
   )
 )
 
+;; Mint BitStable tokens with fee accrual
 (define-public (mint-stablecoin (amount uint))
-  ;; Mints BitStable tokens against vault collateral
   (let (
-      (vault (unwrap! (map-get? vaults tx-sender) ERR_LOW_BALANCE))
-      (current-collateral (get collateral vault))
-      (current-debt (get debt vault))
-      (new-debt (+ current-debt amount))
-      (collateral-value (* current-collateral (var-get last-price)))
-    )
+        (vault (unwrap! (map-get? vaults tx-sender) ERR_LOW_BALANCE))
+        (vault-with-fee (accrue-stability-fee vault))
+        (current-collateral (get collateral vault-with-fee))
+        (current-debt (get debt vault-with-fee))
+        (new-debt (+ current-debt amount))
+        (collateral-value (* current-collateral (var-get last-price)))
+  )
     (begin
       (asserts! (var-get initialized) ERR_NOT_INITIALIZED)
       (asserts! (not (var-get emergency-shutdown)) ERR_EMERGENCY_SHUTDOWN)
       (asserts! (var-get price-valid) ERR_INVALID_PRICE)
-      ;; Enforce minimum collateralization ratio
-      (asserts!
-        (>= (* collateral-value u100)
-          (* new-debt (var-get minimum-collateral-ratio))
-        )
-        ERR_BELOW_MCR
-      )
-      (map-set vaults tx-sender (merge vault { debt: new-debt }))
+      (asserts! (>= (* collateral-value u100) (* new-debt (var-get minimum-collateral-ratio))) ERR_BELOW_MCR)
+      (map-set vaults tx-sender (merge vault-with-fee { debt: new-debt }))
       (ok true)
     )
   )
 )
 
+;; Repay debt with fee accrual
 (define-public (repay-debt (amount uint))
-  ;; Repays BitStable debt to reduce vault obligation
   (let (
-      (vault (unwrap! (map-get? vaults tx-sender) ERR_LOW_BALANCE))
-      (current-debt (get debt vault))
-    )
+        (vault (unwrap! (map-get? vaults tx-sender) ERR_LOW_BALANCE))
+        (vault-with-fee (accrue-stability-fee vault))
+        (current-debt (get debt vault-with-fee))
+  )
     (begin
       (asserts! (var-get initialized) ERR_NOT_INITIALIZED)
       (asserts! (>= current-debt amount) ERR_LOW_BALANCE)
-      (map-set vaults tx-sender (merge vault { debt: (- current-debt amount) }))
+      (map-set vaults tx-sender (merge vault-with-fee { debt: (- current-debt amount) }))
       (ok true)
     )
   )
 )
 
+;; Withdraw collateral with fee accrual
 (define-public (withdraw-collateral (amount uint))
-  ;; Withdraws collateral while maintaining minimum ratios
   (let (
-      (vault (unwrap! (map-get? vaults tx-sender) ERR_LOW_BALANCE))
-      (current-collateral (get collateral vault))
-      (current-debt (get debt vault))
-      (new-collateral (- current-collateral amount))
-      (collateral-value (* new-collateral (var-get last-price)))
-    )
+        (vault (unwrap! (map-get? vaults tx-sender) ERR_LOW_BALANCE))
+        (vault-with-fee (accrue-stability-fee vault))
+        (current-collateral (get collateral vault-with-fee))
+        (current-debt (get debt vault-with-fee))
+        (new-collateral (- current-collateral amount))
+        (collateral-value (* new-collateral (var-get last-price)))
+  )
     (begin
       (asserts! (var-get initialized) ERR_NOT_INITIALIZED)
       (asserts! (not (var-get emergency-shutdown)) ERR_EMERGENCY_SHUTDOWN)
       (asserts! (var-get price-valid) ERR_INVALID_PRICE)
       (asserts! (>= current-collateral amount) ERR_LOW_BALANCE)
-      ;; Ensure withdrawal maintains safe collateralization
       (asserts!
         (or
           (is-eq current-debt u0)
-          (>= (* collateral-value u100)
-            (* current-debt (var-get minimum-collateral-ratio))
-          )
+          (>= (* collateral-value u100) (* current-debt (var-get minimum-collateral-ratio)))
         )
         ERR_BELOW_MCR
       )
       (try! (as-contract (stx-transfer? amount (as-contract tx-sender) tx-sender)))
-      (map-set vaults tx-sender (merge vault { collateral: new-collateral }))
+      (map-set vaults tx-sender (merge vault-with-fee { collateral: new-collateral }))
       (ok true)
     )
   )
 )
 
-;; LIQUIDATION SYSTEM
+;; ========================================
+;; LIQUIDATION
+;; ========================================
 
 (define-public (liquidate (vault-owner principal))
-  ;; Liquidates undercollateralized vaults to protect protocol
   (let (
-      (vault (unwrap! (map-get? vaults vault-owner) ERR_LOW_BALANCE))
-      (collateral (get collateral vault))
-      (debt (get debt vault))
-      (collateral-value (* collateral (var-get last-price)))
-    )
+        (vault (unwrap! (map-get? vaults vault-owner) ERR_LOW_BALANCE))
+        (collateral (get collateral vault))
+        (debt (get debt vault))
+        (collateral-value (* collateral (var-get last-price)))
+  )
     (begin
-      ;; System health checks
       (asserts! (var-get initialized) ERR_NOT_INITIALIZED)
       (asserts! (var-get price-valid) ERR_INVALID_PRICE)
       (asserts! (is-authorized-liquidator tx-sender) ERR_OWNER_ONLY)
-
-      ;; Vault validation
       (asserts! (> debt u0) ERR_INVALID_PARAMETER)
-
-      ;; Confirm vault is below liquidation threshold
-      (asserts!
-        (< (* collateral-value u100) (* debt (var-get liquidation-ratio)))
-        ERR_INSUFFICIENT_COLLATERAL
-      )
-
-      ;; Execute liquidation with reentrancy protection
+      (asserts! (< (* collateral-value u100) (* debt (var-get liquidation-ratio))) ERR_INSUFFICIENT_COLLATERAL)
       (let ((collateral-to-transfer collateral))
         (map-delete vaults vault-owner)
         (try! (as-contract (stx-transfer? collateral-to-transfer (as-contract tx-sender) tx-sender)))
@@ -245,10 +222,11 @@
   )
 )
 
-;; ORACLE PRICE MANAGEMENT
+;; ========================================
+;; ORACLE MANAGEMENT
+;; ========================================
 
 (define-public (update-price (new-price uint))
-  ;; Updates BTC/USD price feed from authorized oracles
   (begin
     (asserts! (is-authorized-oracle tx-sender) ERR_OWNER_ONLY)
     (asserts! (is-valid-price new-price) ERR_INVALID_PARAMETER)
@@ -258,10 +236,11 @@
   )
 )
 
-;; GOVERNANCE & RISK MANAGEMENT
+;; ========================================
+;; GOVERNANCE & RISK
+;; ========================================
 
 (define-public (set-minimum-collateral-ratio (new-ratio uint))
-  ;; Updates minimum collateralization requirement
   (begin
     (asserts! (is-eq tx-sender CONTRACT_OWNER) ERR_OWNER_ONLY)
     (asserts! (is-valid-ratio new-ratio) ERR_INVALID_PARAMETER)
@@ -272,20 +251,16 @@
 )
 
 (define-public (set-liquidation-ratio (new-ratio uint))
-  ;; Updates liquidation threshold ratio
   (begin
     (asserts! (is-eq tx-sender CONTRACT_OWNER) ERR_OWNER_ONLY)
     (asserts! (is-valid-ratio new-ratio) ERR_INVALID_PARAMETER)
-    (asserts! (< new-ratio (var-get minimum-collateral-ratio))
-      ERR_INVALID_PARAMETER
-    )
+    (asserts! (< new-ratio (var-get minimum-collateral-ratio)) ERR_INVALID_PARAMETER)
     (var-set liquidation-ratio new-ratio)
     (ok true)
   )
 )
 
 (define-public (set-stability-fee (new-fee uint))
-  ;; Updates annual stability fee for borrowing
   (begin
     (asserts! (is-eq tx-sender CONTRACT_OWNER) ERR_OWNER_ONLY)
     (asserts! (is-valid-fee new-fee) ERR_INVALID_PARAMETER)
@@ -294,10 +269,11 @@
   )
 )
 
-;; ACCESS CONTROL MANAGEMENT
+;; ========================================
+;; ACCESS CONTROL
+;; ========================================
 
 (define-public (add-liquidator (liquidator principal))
-  ;; Authorizes new liquidator address
   (begin
     (asserts! (is-eq tx-sender CONTRACT_OWNER) ERR_OWNER_ONLY)
     (asserts! (not (is-authorized-liquidator liquidator)) ERR_INVALID_PARAMETER)
@@ -307,7 +283,6 @@
 )
 
 (define-public (remove-liquidator (liquidator principal))
-  ;; Revokes liquidator authorization
   (begin
     (asserts! (is-eq tx-sender CONTRACT_OWNER) ERR_OWNER_ONLY)
     (asserts! (is-authorized-liquidator liquidator) ERR_INVALID_PARAMETER)
@@ -317,7 +292,6 @@
 )
 
 (define-public (add-oracle (oracle principal))
-  ;; Authorizes new price oracle
   (begin
     (asserts! (is-eq tx-sender CONTRACT_OWNER) ERR_OWNER_ONLY)
     (asserts! (not (is-authorized-oracle oracle)) ERR_INVALID_PARAMETER)
@@ -327,7 +301,6 @@
 )
 
 (define-public (remove-oracle (oracle principal))
-  ;; Revokes oracle authorization
   (begin
     (asserts! (is-eq tx-sender CONTRACT_OWNER) ERR_OWNER_ONLY)
     (asserts! (is-authorized-oracle oracle) ERR_INVALID_PARAMETER)
@@ -336,10 +309,11 @@
   )
 )
 
-;; EMERGENCY CONTROLS
+;; ========================================
+;; EMERGENCY
+;; ========================================
 
 (define-public (trigger-emergency-shutdown)
-  ;; Activates emergency shutdown to halt new operations
   (begin
     (asserts! (is-eq tx-sender CONTRACT_OWNER) ERR_OWNER_ONLY)
     (var-set emergency-shutdown true)
@@ -347,20 +321,20 @@
   )
 )
 
-;; READ-ONLY QUERY FUNCTIONS
+;; ========================================
+;; READ-ONLY QUERIES
+;; ========================================
 
 (define-read-only (get-vault (owner principal))
-  ;; Returns vault details for specified owner
   (map-get? vaults owner)
 )
 
 (define-read-only (get-collateral-ratio (owner principal))
-  ;; Calculates current collateralization ratio for vault
   (let (
-      (vault (unwrap! (map-get? vaults owner) ERR_LOW_BALANCE))
-      (collateral (get collateral vault))
-      (debt (get debt vault))
-    )
+        (vault (unwrap! (map-get? vaults owner) ERR_LOW_BALANCE))
+        (collateral (get collateral vault))
+        (debt (get debt vault))
+  )
     (if (is-eq debt u0)
       (ok u0)
       (ok (/ (* collateral (var-get last-price)) debt))
@@ -369,17 +343,14 @@
 )
 
 (define-read-only (is-authorized-liquidator (address principal))
-  ;; Checks if address is authorized liquidator
   (default-to false (map-get? liquidators address))
 )
 
 (define-read-only (is-authorized-oracle (address principal))
-  ;; Checks if address is authorized price oracle
   (default-to false (map-get? price-oracles address))
 )
 
 (define-read-only (get-stability-parameters)
-  ;; Returns current protocol parameters
   {
     minimum-collateral-ratio: (var-get minimum-collateral-ratio),
     liquidation-ratio: (var-get liquidation-ratio),


### PR DESCRIPTION
feat: add time-weighted stability fee accrual to BitStable protocol

- Implemented `accrue-stability-fee` to automatically calculate and update vault debt based on time passed (block height) and configured stability fee.
- Integrated fee accrual into `mint-stablecoin`, `repay-debt`, and `withdraw-collateral` functions to ensure vault debt stays up-to-date.
- Preserves existing vault, liquidation, oracle, governance, and emergency logic.
- Enhances protocol realism and ensures fair, time-proportional fee charges.